### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: npx projen build
       - name: Check for changes
         id: git_diff
-        run: git diff --exit-code || echo "::set-output name=has_changes::true"
+        run: git diff --exit-code || echo "has_changes=true" >> "$GITHUB_OUTPUT"
       - if: steps.git_diff.outputs.has_changes
         name: Commit and push changes (if changed)
         run: 'git add . && git commit -m "chore: self mutation" && git push origin

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -34,7 +34,7 @@ jobs:
         run: npx projen release:beta
       - name: Check for new commits
         id: git_remote
-        run: echo ::set-output name=latest_commit::"$(git ls-remote origin -h ${{
+        run: echo latest_commit="$(git ls-remote origin -h ${{ >> "$GITHUB_OUTPUT"
           github.ref }} | cut -f1)"
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -34,8 +34,7 @@ jobs:
         run: npx projen release:beta
       - name: Check for new commits
         id: git_remote
-        run: echo latest_commit="$(git ls-remote origin -h ${{ >> "$GITHUB_OUTPUT"
-          github.ref }} | cut -f1)"
+        run: echo "latest_commit=\"$(git ls-remote origin -h ${{ github.ref }} | cut -f1)\"" >> "$GITHUB_OUTPUT"
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,7 @@ jobs:
         run: npx projen release:release
       - name: Check for new commits
         id: git_remote
-        run: echo latest_commit="$(git ls-remote origin -h ${{ >> "$GITHUB_OUTPUT"
-          github.ref }} | cut -f1)"
+        run: echo "latest_commit=\"$(git ls-remote origin -h ${{ github.ref }} | cut -f1)\"" >> "$GITHUB_OUTPUT"
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: npx projen release:release
       - name: Check for new commits
         id: git_remote
-        run: echo ::set-output name=latest_commit::"$(git ls-remote origin -h ${{
+        run: echo latest_commit="$(git ls-remote origin -h ${{ >> "$GITHUB_OUTPUT"
           github.ref }} | cut -f1)"
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}

--- a/.github/workflows/upgrade-beta.yml
+++ b/.github/workflows/upgrade-beta.yml
@@ -32,8 +32,8 @@ jobs:
         run: npx projen upgrade
       - name: Build
         id: build
-        run: npx projen build && echo "::set-output name=conclusion::success" || echo
-          "::set-output name=conclusion::failure"
+        run: npx projen build && echo "conclusion=success" || echo >> "$GITHUB_OUTPUT"
+          "conclusion=failure" >> "$GITHUB_OUTPUT"
       - name: Create Patch
         run: |-
           git add .

--- a/.github/workflows/upgrade-beta.yml
+++ b/.github/workflows/upgrade-beta.yml
@@ -32,8 +32,7 @@ jobs:
         run: npx projen upgrade
       - name: Build
         id: build
-        run: npx projen build && echo "conclusion=success" || echo >> "$GITHUB_OUTPUT"
-          "conclusion=failure" >> "$GITHUB_OUTPUT"
+        run: npx projen build && echo "conclusion=success" >> "$GITHUB_OUTPUT" || echo "conclusion=failure" >> "$GITHUB_OUTPUT"
       - name: Create Patch
         run: |-
           git add .
@@ -68,7 +67,8 @@ jobs:
           name: .upgrade.tmp.patch
           path: ${{ runner.temp }}
       - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
+        run:
+          '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
           }}/.upgrade.tmp.patch || echo "Empty patch. Skipping."'
       - name: Create Pull Request
         id: create-pr
@@ -107,7 +107,8 @@ jobs:
           signoff: true
       - name: Update status check
         if: steps.create-pr.outputs.pull-request-url != ''
-        run: "curl -i --fail -X POST -H \"Accept: application/vnd.github.v3+json\" -H
+        run:
+          "curl -i --fail -X POST -H \"Accept: application/vnd.github.v3+json\" -H
           \"Authorization: token ${GITHUB_TOKEN}\"
           https://api.github.com/repos/${{ github.repository }}/check-runs -d
           '{\"name\":\"build\",\"head_sha\":\"github-actions/upgrade-beta\",\"s\

--- a/.github/workflows/upgrade-release.yml
+++ b/.github/workflows/upgrade-release.yml
@@ -32,8 +32,8 @@ jobs:
         run: npx projen upgrade
       - name: Build
         id: build
-        run: npx projen build && echo "::set-output name=conclusion::success" || echo
-          "::set-output name=conclusion::failure"
+        run: npx projen build && echo "conclusion=success" || echo >> "$GITHUB_OUTPUT"
+          "conclusion=failure" >> "$GITHUB_OUTPUT"
       - name: Create Patch
         run: |-
           git add .

--- a/.github/workflows/upgrade-release.yml
+++ b/.github/workflows/upgrade-release.yml
@@ -32,8 +32,7 @@ jobs:
         run: npx projen upgrade
       - name: Build
         id: build
-        run: npx projen build && echo "conclusion=success" || echo >> "$GITHUB_OUTPUT"
-          "conclusion=failure" >> "$GITHUB_OUTPUT"
+        run: npx projen build && echo "conclusion=success" >> "$GITHUB_OUTPUT" || echo "conclusion=failure" >> "$GITHUB_OUTPUT"
       - name: Create Patch
         run: |-
           git add .
@@ -68,7 +67,8 @@ jobs:
           name: .upgrade.tmp.patch
           path: ${{ runner.temp }}
       - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
+        run:
+          '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
           }}/.upgrade.tmp.patch || echo "Empty patch. Skipping."'
       - name: Create Pull Request
         id: create-pr
@@ -107,7 +107,8 @@ jobs:
           signoff: true
       - name: Update status check
         if: steps.create-pr.outputs.pull-request-url != ''
-        run: "curl -i --fail -X POST -H \"Accept: application/vnd.github.v3+json\" -H
+        run:
+          "curl -i --fail -X POST -H \"Accept: application/vnd.github.v3+json\" -H
           \"Authorization: token ${GITHUB_TOKEN}\"
           https://api.github.com/repos/${{ github.repository }}/check-runs -d
           '{\"name\":\"build\",\"head_sha\":\"github-actions/upgrade-release\",\


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter