### PR TITLE
fix: update deployment lambda memory limit

### DIFF
--- a/src/export-backend-asset-handler/index.ts
+++ b/src/export-backend-asset-handler/index.ts
@@ -239,6 +239,7 @@ export class AmplifyExportAssetHandler extends Construct {
         sources: [Source.asset(filePath)],
         destinationKeyPrefix: AMPLIFY_BUILDS,
         prune: false,
+        memoryLimit: 512,
       },
     );
     const stacks = this.exportManifest.props.loadNestedStacks;


### PR DESCRIPTION
Fixes #63

When uploading the zip file of a lambda's build code, a lambda function is used internally to extract the contents of the zip file and copy them to the destination bucket as per this snipper from the [aws-cdk-lib source code](https://github.com/aws/aws-cdk/tree/main/packages/aws-cdk-lib/aws-s3-deployment#aws-s3-deployment-construct-library)
> The BucketDeployment construct synthesizes a Lambda-backed custom CloudFormation resource of type Custom::CDKBucketDeployment into the template. The source bucket/key is set to point to the assets bucket.

> The custom resource invokes its associated Lambda function, which downloads the .zip archive, extracts it and issues aws s3 sync --delete against the destination bucket (in this case websiteBucket). If there is more than one source, the sources will be downloaded and merged pre-deployment at this step.

By default, the lambda function gets created with a memory size of `128 MB`. However, if the size of your zipped lambda package is significantly larger than this, the deployment fails to go through successfully with the error linked being thrown. This addresses the issue by setting a `memoryLimit` of `512 MB` which should be more than enough - considering the zipped lambda size cannot exceed 250MB