### PR TITLE
Feed PR head repo full name and head ref to envs before scripts 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,17 +42,17 @@ jobs:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       - if: steps.git_diff.outputs.has_changes
         name: Update status check (if changed)
-        run: gh api -X POST /repos/"$REPO_FULL_NAME"/check-runs 
+        run: gh api -X POST /repos/$REPO_FULL_NAME/check-runs 
         -F name="build" -F head_sha="$(git rev-parse HEAD)" -F
           status="completed" -F conclusion="success"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name}}
+          PR_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name}}
       - if: steps.git_diff.outputs.has_changes
         name: Cancel workflow (if changed)
-        run: gh api -X POST /repos/"$REPO_FULL_NAME"/actions/runs/${{ github.run_id }}/cancel
+        run: gh api -X POST /repos/$REPO_FULL_NAME/actions/runs/${{ github.run_id }}/cancel
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name}}
+          PR_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name}}
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       - if: steps.git_diff.outputs.has_changes
         name: Update status check (if changed)
-        run: gh api -X POST /repos/$REPO_FULL_NAME/check-runs 
+        run: gh api -X POST /repos/${PR_REPO_FULL_NAME}/check-runs 
         -F name="build" -F head_sha="$(git rev-parse HEAD)" -F
           status="completed" -F conclusion="success"
         env:
@@ -50,7 +50,7 @@ jobs:
           PR_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name}}
       - if: steps.git_diff.outputs.has_changes
         name: Cancel workflow (if changed)
-        run: gh api -X POST /repos/$REPO_FULL_NAME/actions/runs/${{ github.run_id }}/cancel
+        run: gh api -X POST /repos/${PR_REPO_FULL_NAME}/actions/runs/${{ github.run_id }}/cancel
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,19 +37,22 @@ jobs:
       - if: steps.git_diff.outputs.has_changes
         name: Commit and push changes (if changed)
         run: 'git add . && git commit -m "chore: self mutation" && git push origin
-          HEAD:${{ github.event.pull_request.head.ref }}'
+          HEAD:"$PR-HEAD-REF"'
+        env: 
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       - if: steps.git_diff.outputs.has_changes
         name: Update status check (if changed)
-        run: gh api -X POST /repos/${{ github.event.pull_request.head.repo.full_name
-          }}/check-runs -F name="build" -F head_sha="$(git rev-parse HEAD)" -F
+        run: gh api -X POST /repos/"$REPO_FULL_NAME"/check-runs 
+        -F name="build" -F head_sha="$(git rev-parse HEAD)" -F
           status="completed" -F conclusion="success"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name}}
       - if: steps.git_diff.outputs.has_changes
         name: Cancel workflow (if changed)
-        run: gh api -X POST /repos/${{ github.event.pull_request.head.repo.full_name
-          }}/actions/runs/${{ github.run_id }}/cancel
+        run: gh api -X POST /repos/"$REPO_FULL_NAME"/actions/runs/${{ github.run_id }}/cancel
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name}}
     container:
       image: jsii/superchain:1-buster-slim-node14


### PR DESCRIPTION
Fixes #
Passing potentially untrusted inputs to env variable before running script, recommended by this: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks 