### PR TITLE
chore: batch dependabot updates 2026-06-17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.241.0",
         "constructs": "^10.5.0",
         "fs-extra": "10.1.0",
         "lodash.get": "^4.4.2",
@@ -26,7 +25,7 @@
         "@types/lodash.get": "^4.4.7",
         "@types/node": "^14.18.21",
         "@types/uuid": "^8.3.4",
-        "aws-cdk-lib": "2.241.0",
+        "aws-cdk-lib": "2.246.0",
         "constructs": "10.5.0",
         "jest": "^30.2.0",
         "jest-junit": "^12",
@@ -46,7 +45,7 @@
         "node": ">= 14.17.6"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.241.0",
+        "aws-cdk-lib": "2.246.0",
         "constructs": "^10.5.0"
       }
     },
@@ -65,9 +64,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-      "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -75,15 +74,15 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -92,7 +91,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1783,9 +1782,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.241.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.241.0.tgz",
-      "integrity": "sha512-v0uDNDqJt6oJ/ZHRp+KIn4xzhF518uKpZxY8fi12bO+dt505t6fCqCaqXuadznokrAyWwIae6q3ByWJfmZzQjA==",
+      "version": "2.246.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.246.0.tgz",
+      "integrity": "sha512-7OtF95mss9dWohopCNQKAlNFrMJwgOIvNTNgoOWWcKhULBf6UxKCaf6ATlnuysIWRGf2DHgcval/4+yySOKRBw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -1805,8 +1804,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.263",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.1.1",
-        "@aws-cdk/cloud-assembly-schema": "^52.1.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.0",
+        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -1817,17 +1816,17 @@
         "punycode": "^2.3.1",
         "semver": "^7.7.4",
         "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "yaml": "1.10.3"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
         "constructs": "^10.5.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.1.1",
+      "version": "2.2.0",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1837,13 +1836,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
@@ -1856,7 +1855,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.7.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2204,7 +2203,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "organization": true
   },
   "devDependencies": {
-    "aws-cdk-lib": "2.241.0",
+    "aws-cdk-lib": "2.246.0",
     "constructs": "10.5.0",
     "@types/fs-extra": "^8.1.2",
     "@types/jest": "^30.0.0",
@@ -57,11 +57,11 @@
     "yaml": "^2.2.2"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.241.0",
+    "aws-cdk-lib": "^2.246.0",
     "constructs": "^10.5.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.241.0",
+    "aws-cdk-lib": "^2.246.0",
     "constructs": "^10.5.0",
     "fs-extra": "10.1.0",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
Batches open Dependabot PRs as of 2026-06-17. Closes #100 #95 #93 #92 #90 (uuid #97 skipped — ESM-only, breaks Jest)